### PR TITLE
fix: using currentTarget for node data

### DIFF
--- a/src/substrait-to-d3.js
+++ b/src/substrait-to-d3.js
@@ -161,7 +161,7 @@ function drawGraph(pre_nodes, pre_links, use_drag = true) {
   // displaying node data on click
   node.on("click", function (d) {
     let node = document.getElementById("nodeData");
-    let nodeData = pre_nodes.get(d["target"]["__data__"]["name"]);
+    let nodeData = pre_nodes.get(d["currentTarget"]["__data__"]["name"]);
     node.innerHTML = "<h3>" + typeToLabel(nodeData.type) + " Node</h3>";
     node.innerHTML += "<h5>Node Name:" + nodeData.id + "</h5>";
 


### PR DESCRIPTION
Previously, for fetching the node details, the `target` attribute of the node object was used. But, the foreign object which holds the node icon, doesn't possess a `target` attribute, thus `currentTarget` attribute should be used instead.